### PR TITLE
Add Test_configsAreEqual

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -235,6 +235,22 @@ frontend public
   acl secure_redirect base,map_reg_int(/var/lib/haproxy/conf/os_route_http_redirect.map) -m bool
   redirect scheme https if secure_redirect
 
+    {{- range $idx, $http_request_header := .HTTPRequestHeaders }}
+      {{- if eq $http_request_header.Action "Set" }}
+  http-request set-header {{ $http_request_header.Name }} {{ $http_request_header.Value }}
+      {{- else if eq $http_request_header.Action "Delete" }}
+  http-request del-header {{ $http_request_header.Name }}
+      {{- end }}
+    {{- end }}
+
+    {{- range $idx, $http_response_header := .HTTPResponseHeaders }}
+      {{- if eq $http_response_header.Action "Set" }}
+  http-response set-header {{ $http_response_header.Name }} {{ $http_response_header.Value }}
+      {{- else if eq $http_response_header.Action "Delete" }}
+  http-response del-header {{ $http_response_header.Name }}
+      {{- end }}
+    {{- end }}
+
   use_backend %[base,map_reg(/var/lib/haproxy/conf/os_http_be.map)]
 
   default_backend openshift_default
@@ -355,6 +371,22 @@ frontend fe_sni
   http-request set-header X-SSL-Client-DER       %{+Q}[ssl_c_der,base64]
     {{- end }}
 
+    {{- range $idx, $http_request_header := .HTTPRequestHeaders }}
+      {{- if eq $http_request_header.Action "Set" }}
+  http-request set-header {{ $http_request_header.Name }} {{ $http_request_header.Value }}
+      {{- else if eq $http_request_header.Action "Delete" }}
+  http-request del-header {{ $http_request_header.Name }}
+      {{- end }}
+    {{- end }}
+
+    {{- range $idx, $http_response_header := .HTTPResponseHeaders }}
+      {{- if eq $http_response_header.Action "Set" }}
+  http-response set-header {{ $http_response_header.Name }} {{ $http_response_header.Value }}
+      {{- else if eq $http_response_header.Action "Delete" }}
+  http-response del-header {{ $http_response_header.Name }}
+      {{- end }}
+    {{- end }}
+
   # map to backend
   # Search from most specific to general path (host case).
   # Note: If no match, haproxy uses the default_backend, no other
@@ -437,6 +469,22 @@ frontend fe_no_sni
   http-request set-header X-SSL-Client-NotBefore %{+Q}[ssl_c_notbefore]
   http-request set-header X-SSL-Client-NotAfter  %{+Q}[ssl_c_notafter]
   http-request set-header X-SSL-Client-DER       %{+Q}[ssl_c_der,base64]
+    {{- end }}
+
+    {{- range $idx, $http_request_header := .HTTPRequestHeaders }}
+      {{- if eq $http_request_header.Action "Set" }}
+  http-request set-header {{ $http_request_header.Name }} {{ $http_request_header.Value }}
+      {{- else if eq $http_request_header.Action "Delete" }}
+  http-request del-header {{ $http_request_header.Name }}
+      {{- end }}
+    {{- end }}
+
+    {{- range $idx, $http_response_header := .HTTPResponseHeaders }}
+      {{- if eq $http_response_header.Action "Set" }}
+  http-response set-header {{ $http_response_header.Name }} {{ $http_response_header.Value }}
+      {{- else if eq $http_response_header.Action "Delete" }}
+  http-response del-header {{ $http_response_header.Name }}
+      {{- end }}
     {{- end }}
 
   # map to backend
@@ -623,6 +671,21 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-response set-header Strict-Transport-Security '{{ $hsts }}'
           {{- end }}{{/* hsts header */}}
         {{- end }}{{/* is "edge" or "reencrypt" */}}
+
+          {{- range $idx, $http_request_header := $cfg.HTTPRequestHeaders }}
+            {{- if eq $http_request_header.Action "Set" }}
+  http-request set-header {{ $http_request_header.Name }} {{ $http_request_header.Value }}
+            {{- else if eq $http_request_header.Action "Delete" }}
+  http-request del-header {{ $http_request_header.Name }}
+            {{- end }}
+          {{- end }}
+          {{- range $idx, $http_response_header := $cfg.HTTPResponseHeaders }}
+            {{- if eq $http_response_header.Action "Set" }}
+  http-response set-header {{ $http_response_header.Name }} {{ $http_response_header.Value }}
+            {{- else if eq $http_response_header.Action "Delete" }}
+  http-response del-header {{ $http_response_header.Name }}
+            {{- end }}
+          {{- end }}
 
         {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
           {{- if ge $weight 0 }}{{/* weight=0 is reasonable to keep existing connections to backends with cookies as we can see the HTTP headers */}}

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -126,6 +126,10 @@ type TemplateRouter struct {
 	CaptureHTTPCookie                   *templateplugin.CaptureHTTPCookie
 	HTTPHeaderNameCaseAdjustmentsString string
 	HTTPHeaderNameCaseAdjustments       []templateplugin.HTTPHeaderNameCaseAdjustment
+	HTTPResponseHeadersString           string
+	HTTPResponseHeaders                 []templateplugin.HTTPHeader
+	HTTPRequestHeadersString            string
+	HTTPRequestHeaders                  []templateplugin.HTTPHeader
 
 	TemplateRouterConfigManager
 }
@@ -182,6 +186,8 @@ func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.CaptureHTTPResponseHeadersString, "capture-http-response-headers", env("ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS", ""), "A comma-delimited list of HTTP response header names and maximum header value lengths that should be captured for logging. Each item must have the following form: name:maxLength")
 	flag.StringVar(&o.CaptureHTTPCookieString, "capture-http-cookie", env("ROUTER_CAPTURE_HTTP_COOKIE", ""), "Name and maximum length of HTTP cookie that should be captured for logging.  The argument must have the following form: name:maxLength. Append '=' to the name to indicate that an exact match should be performed; otherwise a prefix match will be performed.  The value of first cookie that matches the name is captured.")
 	flag.StringVar(&o.HTTPHeaderNameCaseAdjustmentsString, "http-header-name-case-adjustments", env("ROUTER_H1_CASE_ADJUST", ""), "A comma-delimited list of HTTP header names that should have their case adjusted. Each item must be a valid HTTP header name and should have the desired capitalization.")
+	flag.StringVar(&o.HTTPResponseHeadersString, "set-delete-http-response-header", env("ROUTER_HTTP_RESPONSE_HEADERS", ""), "A comma-delimited list of HTTP response header names and values that should be set/deleted.")
+	flag.StringVar(&o.HTTPRequestHeadersString, "set-delete-http-request-header", env("ROUTER_HTTP_REQUEST_HEADERS", ""), "A comma-delimited list of HTTP request header names and values that should be set/deleted.")
 }
 
 type RouterStats struct {
@@ -285,6 +291,99 @@ func parseCaptureHeaders(in string) ([]templateplugin.CaptureHTTPHeader, error) 
 	}
 
 	return captureHeaders, nil
+}
+
+func parseHeadersToBeSetOrDeleted(in string) ([]templateplugin.HTTPHeader, error) {
+	var captureHeaders []templateplugin.HTTPHeader
+	var capture templateplugin.HTTPHeader
+	var err error
+	if len(in) == 0 {
+		return captureHeaders, fmt.Errorf("encoded header string not present.")
+	}
+	if len(in) > 0 {
+		for _, header := range strings.Split(in, ",") {
+			parts := strings.Split(header, ":")
+			num := len(parts)
+			switch num {
+			default:
+				return captureHeaders, fmt.Errorf("invalid HTTP header input specification: %v", header)
+			case 3:
+				{
+					headerName, err := url.QueryUnescape(parts[0])
+					if err != nil {
+						return captureHeaders, fmt.Errorf("failed to decode percent encoding: %v", parts[0])
+					}
+					err = checkValidHeaderName(headerName)
+					if err != nil {
+						return captureHeaders, err
+					}
+					headerValue, err := url.QueryUnescape(parts[1])
+					if err != nil {
+						return captureHeaders, fmt.Errorf("failed to decode percent encoding: %v", parts[1])
+					}
+					sanitizedHeaderValue := templateplugin.SanitizeHeaderValue(headerValue)
+					action, err := url.QueryUnescape(parts[2])
+					if err != nil {
+						return captureHeaders, fmt.Errorf("failed to decode percent encoding: %v", parts[2])
+					}
+					err = checkValidAction(action)
+					if err != nil {
+						return captureHeaders, err
+					}
+					capture = templateplugin.HTTPHeader{
+						Name:   headerName,
+						Value:  sanitizedHeaderValue,
+						Action: routev1.RouteHTTPHeaderActionType(action),
+					}
+					captureHeaders = append(captureHeaders, capture)
+				}
+			case 2:
+				{
+					headerName, err := url.QueryUnescape(parts[0])
+					if err != nil {
+						return captureHeaders, fmt.Errorf("failed to decode percent encoding: %v", parts[0])
+					}
+					err = checkValidHeaderName(headerName)
+					if err != nil {
+						return captureHeaders, err
+					}
+					action, err := url.QueryUnescape(parts[1])
+					if err != nil {
+						return captureHeaders, fmt.Errorf("failed to decode percent encoding: %v", parts[1])
+					}
+					err = checkValidAction(action)
+					if err != nil {
+						return captureHeaders, err
+					}
+					capture = templateplugin.HTTPHeader{
+						Name:   headerName,
+						Action: routev1.RouteHTTPHeaderActionType(action),
+					}
+					captureHeaders = append(captureHeaders, capture)
+				}
+			}
+		}
+	}
+
+	return captureHeaders, err
+}
+
+func checkValidAction(action string) error {
+	if action != string(routev1.Set) && action != string(routev1.Delete) {
+		return fmt.Errorf("invalid action %s", action)
+	} else {
+		return nil
+	}
+}
+
+func checkValidHeaderName(headerName string) error {
+	// RFC 2616, section 4.2, states that the header name
+	// must be a valid token.
+	if !validTokenRE.MatchString(headerName) {
+		return fmt.Errorf("invalid HTTP header name: %s", headerName)
+	} else {
+		return nil
+	}
 }
 
 func parseCaptureCookie(in string) (*templateplugin.CaptureHTTPCookie, error) {
@@ -392,6 +491,22 @@ func (o *TemplateRouterOptions) Complete() error {
 		return err
 	}
 	o.CaptureHTTPResponseHeaders = captureHTTPResponseHeaders
+
+	if len(o.HTTPResponseHeadersString) != 0 {
+		httpResponseHeaders, err := parseHeadersToBeSetOrDeleted(o.HTTPResponseHeadersString)
+		if err != nil {
+			return err
+		}
+		o.HTTPResponseHeaders = httpResponseHeaders
+	}
+
+	if len(o.HTTPRequestHeadersString) != 0 {
+		httpRequestHeaders, err := parseHeadersToBeSetOrDeleted(o.HTTPRequestHeadersString)
+		if err != nil {
+			return err
+		}
+		o.HTTPRequestHeaders = httpRequestHeaders
+	}
 
 	captureHTTPCookie, err := parseCaptureCookie(o.CaptureHTTPCookieString)
 	if err != nil {
@@ -648,6 +763,8 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		CaptureHTTPResponseHeaders:    o.CaptureHTTPResponseHeaders,
 		CaptureHTTPCookie:             o.CaptureHTTPCookie,
 		HTTPHeaderNameCaseAdjustments: o.HTTPHeaderNameCaseAdjustments,
+		HTTPResponseHeaders:           o.HTTPResponseHeaders,
+		HTTPRequestHeaders:            o.HTTPRequestHeaders,
 	}
 
 	svcFetcher := templateplugin.NewListWatchServiceLookup(kc.CoreV1(), o.ResyncInterval, o.Namespace)

--- a/pkg/cmd/infra/router/template_test.go
+++ b/pkg/cmd/infra/router/template_test.go
@@ -1,0 +1,135 @@
+package router
+
+import (
+	routev1 "github.com/openshift/api/route/v1"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	templateplugin "github.com/openshift/router/pkg/router/template"
+)
+
+func TestParseHeadersToBeSetOrDeleted(t *testing.T) {
+	testCases := []struct {
+		description        string
+		inputValue         string
+		expectedValue      []templateplugin.HTTPHeader
+		expectErrorMessage string
+	}{
+		{
+			description: "should percent decode the single header value",
+			inputValue:  "Accept:text%2Fplain%2C+text%2Fhtml:Set",
+			expectedValue: []templateplugin.HTTPHeader{
+				{Name: "Accept", Value: "'text/plain, text/html'", Action: routev1.Set},
+			},
+			expectErrorMessage: "",
+		},
+		{
+			description:        "should not percent decode the invalid double encoded single header value as it can't be split either in 2 or 3 parts",
+			inputValue:         "Content-Location%3A%252Fmy-first-blog-post%3ASet",
+			expectedValue:      nil,
+			expectErrorMessage: "invalid HTTP header input specification: Content-Location%3A%252Fmy-first-blog-post%3ASet",
+		},
+		{
+			description: "should percent decode the multiple response header values",
+			inputValue:  "X-Frame-Options:DENY:Set,X-XSS-Protection:1%3Bmode%3Dblock:Set,x-forwarded-client-cert:%25%7B%2BQ%7D%5Bssl_c_der%2Cbase64%5D:Set",
+			expectedValue: []templateplugin.HTTPHeader{
+				{Name: "X-Frame-Options", Value: "'DENY'", Action: routev1.Set},
+				{Name: "X-XSS-Protection", Value: "'1;mode=block'", Action: routev1.Set},
+				{Name: "x-forwarded-client-cert", Value: "'%{+Q}[ssl_c_der,base64]'", Action: routev1.Set},
+			},
+			expectErrorMessage: "",
+		},
+		{
+
+			description: "should percent decode the multiple request header values",
+			inputValue:  "Accept:text%2Fplain%2C+text%2Fhtml:Set,Accept-Encoding:Delete",
+			expectedValue: []templateplugin.HTTPHeader{
+				{Name: "Accept", Value: "'text/plain, text/html'", Action: routev1.Set},
+				{Name: "Accept-Encoding", Action: routev1.Delete},
+			},
+			expectErrorMessage: "",
+		},
+		{
+			description: "should percent decode the multiple header values with simple non encoded strings",
+			inputValue:  "X-Frame-Options:DENY:Set",
+			expectedValue: []templateplugin.HTTPHeader{
+				{Name: "X-Frame-Options", Value: "'DENY'", Action: routev1.Set},
+			},
+			expectErrorMessage: "",
+		},
+		{
+			description:        "when Action is `Set` it should not percent decode the incorrectly encoded value part Eg: percent is not followed by two hexadecimal digits",
+			inputValue:         "x-forwarded-client-cert:%25%7B%2BQ%7D%5Bssl_c_der%2Cbase64%5:Set",
+			expectedValue:      nil,
+			expectErrorMessage: "failed to decode percent encoding: %25%7B%2BQ%7D%5Bssl_c_der%2Cbase64%5",
+		},
+		{
+			description:        "invalid incorrectly encoded Action when header input spec has 2 parts",
+			inputValue:         "Accept-Encoding:Delete%2",
+			expectedValue:      nil,
+			expectErrorMessage: "failed to decode percent encoding: Delete%2",
+		},
+		{
+			description:        "invalid incorrectly encoded Action when header input spec has 3 parts",
+			inputValue:         "X-Frame-Options:DENY:Delete%2",
+			expectedValue:      nil,
+			expectErrorMessage: "failed to decode percent encoding: Delete%2",
+		},
+		{
+			description:        "invalid Action when header input spec has 3 parts",
+			inputValue:         "X-Frame-Options:DENY:Bad",
+			expectedValue:      nil,
+			expectErrorMessage: "invalid action Bad",
+		},
+		{
+			description:        "invalid Action when header input spec has 2 parts",
+			inputValue:         "X-Frame-Options:Bad",
+			expectedValue:      nil,
+			expectErrorMessage: "invalid action Bad",
+		},
+		{
+			description:        "should not allow specifying headers with no action or value",
+			inputValue:         "X-Frame-Options",
+			expectErrorMessage: "invalid HTTP header input specification: X-Frame-Options",
+		},
+		{
+			description:        "should not allow blank values for headers",
+			inputValue:         "",
+			expectedValue:      nil,
+			expectErrorMessage: "encoded header string not present.",
+		},
+		{
+			description:        "should fail with incorrect header name when HTTP header input specification has 3 parts",
+			inputValue:         "X-Frame-Options**!=:DENY:Set",
+			expectedValue:      nil,
+			expectErrorMessage: "invalid HTTP header name: X-Frame-Options**!=",
+		},
+		{
+			description:        "should fail with incorrect header name when HTTP header input specification has 2 parts",
+			inputValue:         "X-Frame-Options**!=:Delete",
+			expectedValue:      nil,
+			expectErrorMessage: "invalid HTTP header name: X-Frame-Options**!=",
+		},
+		{
+			description:        "should fail when header spec consists of more than 3 parts than Name:Value:Action",
+			inputValue:         "X-Frame-Options:DENY:Set:Invalid",
+			expectedValue:      nil,
+			expectErrorMessage: "invalid HTTP header input specification: X-Frame-Options:DENY:Set:Invalid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			switch actualValue, actualErrorMessage := parseHeadersToBeSetOrDeleted(tc.inputValue); {
+			case !cmp.Equal(actualValue, tc.expectedValue):
+				t.Errorf(" expected %s, got %s", tc.expectedValue, actualValue)
+			case tc.expectErrorMessage == "" && actualErrorMessage != nil && actualErrorMessage.Error() != "":
+				t.Fatalf("unexpected error: %v", actualErrorMessage)
+			case tc.expectErrorMessage != "" && actualErrorMessage != nil && actualErrorMessage.Error() == "":
+				t.Fatalf("got nil, expected %v", tc.expectErrorMessage)
+			case actualErrorMessage != nil && tc.expectErrorMessage != actualErrorMessage.Error():
+				t.Fatalf("unexpected error: %v, expected: %v", actualErrorMessage, tc.expectErrorMessage)
+			}
+		})
+	}
+}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -445,7 +445,7 @@ func TestConfigTemplate(t *testing.T) {
 		for _, expectation := range expectations {
 			t.Run(name, func(t *testing.T) {
 				if err := expectation.Match(parser); err != nil {
-					t.Fatalf(err.Error())
+					t.Fatal(err.Error())
 				}
 			})
 		}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -445,6 +445,11 @@ func TestConfigTemplate(t *testing.T) {
 		for _, expectation := range expectations {
 			t.Run(name, func(t *testing.T) {
 				if err := expectation.Match(parser); err != nil {
+					if content, err := ioutil.ReadFile(config); err != nil {
+						t.Error(err)
+					} else {
+						t.Log("haproxy.config:", string(content))
+					}
 					t.Fatal(err.Error())
 				}
 			})

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -66,6 +66,8 @@ type TemplatePluginConfig struct {
 	CaptureHTTPResponseHeaders    []CaptureHTTPHeader
 	CaptureHTTPCookie             *CaptureHTTPCookie
 	HTTPHeaderNameCaseAdjustments []HTTPHeaderNameCaseAdjustment
+	HTTPResponseHeaders           []HTTPHeader
+	HTTPRequestHeaders            []HTTPHeader
 }
 
 // RouterInterface controls the interaction of the plugin with the underlying router implementation
@@ -160,6 +162,8 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 		captureHTTPResponseHeaders:    cfg.CaptureHTTPResponseHeaders,
 		captureHTTPCookie:             cfg.CaptureHTTPCookie,
 		httpHeaderNameCaseAdjustments: cfg.HTTPHeaderNameCaseAdjustments,
+		httpResponseHeaders:           cfg.HTTPResponseHeaders,
+		httpRequestHeaders:            cfg.HTTPRequestHeaders,
 	}
 	router, err := newTemplateRouter(templateRouterCfg)
 	return newDefaultTemplatePlugin(router, cfg.IncludeUDP, lookupSvc), err

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1431,7 +1431,15 @@ func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey
 
 // configsAreEqual determines whether the given service alias configs can be considered equal.
 // This may be useful in determining whether a new service alias config is the same as an
-// existing one or represents an update to its state.
+// existing one or represents an update to its state.  This function should only be used for
+// route updates.
+//
+// This function does not check the ServiceUnitNames or ActiveServiceUnits fields because if
+// either of these fields did change, then the ServiceUnits field would change as well, and
+// this function does check the ServiceUnits field.  Similarly, the ActiveEndpoints field
+// cannot change as a result of a route update unless ServiceUnits changes too.  Note that
+// ActiveEndpoints could change as the result of an endpoints update, but configsAreEqual is
+// only used when handling route updates.
 func configsAreEqual(config1, config2 *ServiceAliasConfig) bool {
 	return config1.Name == config2.Name &&
 		config1.Namespace == config2.Namespace &&

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -74,6 +74,12 @@ type ServiceAliasConfig struct {
 
 	// ActiveEndpoints is a count of the route endpoints that are part of a service unit with a non-zero weight
 	ActiveEndpoints int
+
+	// HTTPResponseHeaders has route-specific custom HTTP response headers.
+	HTTPResponseHeaders []HTTPHeader
+
+	// HTTPResponseHeaders has route-specific custom HTTP request headers.
+	HTTPRequestHeaders []HTTPHeader
 }
 
 type ServiceAliasConfigStatus string
@@ -234,6 +240,18 @@ type CaptureHTTPHeader struct {
 
 	// MaxLength specifies a maximum length for the header value.
 	MaxLength int
+}
+
+// HTTPHeader specifies an HTTP header that should be set or deleted.
+type HTTPHeader struct {
+	// Name specifies an HTTP header name.
+	Name string
+
+	// Value specifies the header value.
+	Value string
+
+	// Action specifies the action to be performed.
+	Action routev1.RouteHTTPHeaderActionType
 }
 
 // CaptureHTTPCookie specifies an HTTP cookie that should be captured


### PR DESCRIPTION
* `pkg/router/template/router.go` (`configsAreEqual`): Add a comment explaining why this function does not check the `ServiceUnitNames`, `ActiveServiceUnits`, or `ActiveEndpoints` fields.
* `pkg/router/template/router_test.go` (`Test_configsAreEqual`): New test. Verify that `configsAreEqual` behaves correctly.
